### PR TITLE
Add fuzz target for bitmap image loading

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = src docs
+SUBDIRS = src docs test
 aclocaldir = @aclocaldir@
 aclocal_DATA = KXL.m4
 EXTRA_DIST = COPYING ChangeLog README KXL.m4

--- a/configure.ac
+++ b/configure.ac
@@ -23,4 +23,15 @@ AC_CHECK_FUNCS(select)
 aclocaldir='${datadir}/aclocal'
 AC_SUBST(aclocaldir)
 
-AC_OUTPUT([KXL.spec Makefile src/Makefile docs/Makefile test/Makefile])
+AC_ARG_ENABLE([test],
+  [AS_HELP_STRING([--enable-test], [enable fuzz testing KXL_LoadBitmap
+  @<:@default=no@:>@])],
+  [test=$enableval], [test=no])
+
+if test x"$test" = xyes; then
+  AC_DEFINE([TEST], [1], [Define if building fuzz program])
+  AC_SUBST([TEST])
+  AC_CONFIG_FILES([test/Makefile])
+fi
+
+AC_OUTPUT([KXL.spec Makefile src/Makefile docs/Makefile])

--- a/configure.ac
+++ b/configure.ac
@@ -34,4 +34,6 @@ if test x"$test" = xyes; then
   AC_CONFIG_FILES([test/Makefile])
 fi
 
+AM_CONDITIONAL([ENABLE_TEST], [test x"$test" = xyes])
+
 AC_OUTPUT([KXL.spec Makefile src/Makefile docs/Makefile])

--- a/configure.ac
+++ b/configure.ac
@@ -23,4 +23,4 @@ AC_CHECK_FUNCS(select)
 aclocaldir='${datadir}/aclocal'
 AC_SUBST(aclocaldir)
 
-AC_OUTPUT([KXL.spec Makefile src/Makefile docs/Makefile])
+AC_OUTPUT([KXL.spec Makefile src/Makefile docs/Makefile test/Makefile])

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
 bin_PROGRAMS = sample
 sample_SOURCES = sample.c
 sample_CFLAGS = -g -O3 -I../src -L/usr/local/lib64
-sample_LDFLAGS = -lKXL
+sample_LDFLAGS = -lKXL -lX11 -lpulse-simple -lpulse

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,0 +1,4 @@
+bin_PROGRAMS = sample
+sample_SOURCES = sample.c
+sample_CFLAGS = -g -O3 -I../src -L/usr/local/lib64
+sample_LDFLAGS = -lKXL

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,3 +2,11 @@ bin_PROGRAMS = sample
 sample_SOURCES = sample.c
 sample_CFLAGS = -g -O3 -I../src -L/usr/local/lib64
 sample_LDFLAGS = -lKXL -lX11 -lpulse-simple -lpulse
+
+#sample.bc is LLVM IR bitcode
+if ENABLE_TEST
+TEST_TARGETS = sample sample.bc sample.o
+endif
+
+clean-local:
+	rm -f $(TEST_TARGETS)

--- a/test/sample.c
+++ b/test/sample.c
@@ -1,0 +1,39 @@
+// sample.c
+#include < KXL.h>
+
+int main(void)
+{
+  Bool flag = False ;
+
+  // Create a window by 100x100.
+  // event receives only the bottom of a re-drawing event and key presss.
+  // If return key is pushed, it will end.
+  KXL_CreateWindow(100, 100, "sample"
+                   KXL_EVENT_EXPOSURE_MASK |
+                   KXL_EVENT_KEY_PRESS_MASK);
+
+  while(flag != True ){
+    // event loop
+    while(KXL_CheckEvents()) {
+      // which acquires a event
+      switch(KXL_GetEvents()) {
+      case KXL_EVENT_EXPOSE: // event of re-drawing
+        // A frame is cleared
+        KXL_ClearFrameImm(0, 0, 100, 100);
+        // "sample" is drawn
+        KXL_PutText(30, 50, "sample");
+        / A frame is made to reflect in a window
+        KXL_UpDateImm(0, 0, 100, 100);
+        break;
+      case KXL_EVENT_KEY_PRESS: // event of key press
+        // If a return key was pushed, it will end
+        if (KXL_GetKey() == KXL_KEY_Return)
+          flag = True;
+        break ;
+      }
+    }
+  }
+  // A window is closed
+  KXL_DeleteWindow();
+  return 0;
+}

--- a/test/sample.c
+++ b/test/sample.c
@@ -3,7 +3,7 @@
 
 int main(int argc, char** argv)
 {
-  Bool flag = False;
+  Bool flag = True;
 
   // Create a window by 100x100.
   // event receives only the bottom of a re-drawing event and key presss.

--- a/test/sample.c
+++ b/test/sample.c
@@ -1,16 +1,17 @@
 // sample.c
-#include < KXL.h>
+#include <KXL.h>
 
-int main(void)
+int main(int argc, char** argv)
 {
-  Bool flag = False ;
+  Bool flag = False;
 
   // Create a window by 100x100.
   // event receives only the bottom of a re-drawing event and key presss.
   // If return key is pushed, it will end.
-  KXL_CreateWindow(100, 100, "sample"
+  KXL_CreateWindow(100, 100, "sample",
                    KXL_EVENT_EXPOSURE_MASK |
                    KXL_EVENT_KEY_PRESS_MASK);
+  KXL_Image *theImage = KXL_LoadBitmap(argv[1], 0);
 
   while(flag != True ){
     // event loop
@@ -21,8 +22,8 @@ int main(void)
         // A frame is cleared
         KXL_ClearFrameImm(0, 0, 100, 100);
         // "sample" is drawn
-        KXL_PutText(30, 50, "sample");
-        / A frame is made to reflect in a window
+        KXL_PutImage(theImage, 0, 0);
+        // A frame is made to reflect in a window
         KXL_UpDateImm(0, 0, 100, 100);
         break;
       case KXL_EVENT_KEY_PRESS: // event of key press
@@ -33,6 +34,7 @@ int main(void)
       }
     }
   }
+  KXL_DeleteImage(theImage);
   // A window is closed
   KXL_DeleteWindow();
   return 0;


### PR DESCRIPTION
This pull request adds sample.c from doc/being.html, modified to accept a single bitmap filename as the first argument.

To fuzz `KXL_LoadBitmap` with [AFL plus plus](https://github.com/AFLplusplus/AFLplusplus):
1. Compile and install AFL++ (LTO mode is best, but requires a recent Clang version)
2. Change the `flag` to True in _test/sample.c_
3. `./configure CC=afl-clang-lto && make`
4. `mkdir test/input test/output`
5. Copy a few small bitmap files from Geki2 to test/input, e.g. `enemyshot1.bmp  enemyshot2.bmp  enemyshot3.bmp mylaser1.bmp  mylaser2.bmp  myshot.bmp`
6. `cd test`
7. `afl-fuzz -i input -o output ./sample @@`

If it already says there's more than 25 min of fuzzing results, pass `-i -` instead of `-i output`.

**Note**: you may have to do `echo core | sudo tee /proc/sys/kernel/core_pattern` so that AFL++ can detect that the `sample` program dumped core.

TODO:
- [x] Optionally compile fuzz target. It should not be mandatory.
- [x] Delete `test/sample` when doing `make clean`