### PR TITLE
Actually make building tests optional.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,8 @@
+if ENABLE_TEST
 SUBDIRS = src docs test
+else
+SUBDIRS = src docs
+endif
 aclocaldir = @aclocaldir@
 aclocal_DATA = KXL.m4
 EXTRA_DIST = COPYING ChangeLog README KXL.m4


### PR DESCRIPTION
When building without having configured with tests enabled before, `test/Makefile` is missing, so make complains "No rule to make target 'all'". d54ff6c4d67409df5552e1f3eaf848a7c3cc2122 claims that the commit makes building with tests optional, but that is true only if the user has configured with `--enable-test` before.

This PR fixes that by adding a condition in Makefile.am so that the `test` directory isn't checked when running `make` if the user has never built libKXL with tests enabled.