### PR TITLE
Fix infinite loop

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,37 @@
+Unreleased Version 1.2.5 [9/9/2023]
+	- KXL_ReadBitmapHeader no longer loops indefinitely on corrupted BMPs.
+	- KXL_LoadBitmap and KXL_ReadBitmapHeader will fail instead of exiting your program.
+	- Documented KXL_ReadBitmapHeader.
+	- Added AFL++ sample.c fuzz target in the test/ directory.
+	- More fuzzing friendly because there are now fewer exit calls.
+-------------------------------------------------------------------------------
+Release Version 1.2.4 [30/9/2021]
+	- Fix incompatible pointer type warning.
+-------------------------------------------------------------------------------
+Release Version 1.2.3-1 [29/9/2021]
+	- Fix some pointer sign warnings
+-------------------------------------------------------------------------------
+Release version 1.2.2-1 [6/3/2020]
+	- Fix Valgrind warning "Invalid read of size 8" in KXL_PlaySound
+	- Zero bitmap data to silence Valgrind warning
+-------------------------------------------------------------------------------
+Release Version 1.2.1-1 [5/3/2020]
+	- Fix Valgrind warning write(buf) points to uninitialised byte(s)
+-------------------------------------------------------------------------------
+Release Version 1.2.0-2 [4/3/2020]
+	- Fix rpmbuild failing to find KXL library in lib64.
+-------------------------------------------------------------------------------
+Release Version 1.2.0-1 [4/3/2020]
+	- Use PulseAudio by default for sound output.
+-------------------------------------------------------------------------------
+Release Version 1.1.6-1 [22/12/2019]
+	- Change obsolete Copyright tag to License tag
+	- Fix typo in format string.
+	- Fix commented out KXL_KEY_Bracketright
+	- Fix "implicit declaration of built-in function" warnings
+	- Fix a conditional jump or move error from Valgrind
+	- Fix approx 1MB memory leak in KXL_Font()
+-------------------------------------------------------------------------------
 Release Version 1.1.5 [19/1/2002]
 	- KXL_UpDateRect function was added.
 	- KXL_UpDateImm function was added.

--- a/docs/KXL.html
+++ b/docs/KXL.html
@@ -54,6 +54,7 @@ Top
   </dd>
   <dd><b>Image-related description</b>
   <br> - <a href="./kxlloadbitmap.html">           KXL_LoadBitmap</a>
+  <br> - <a href="./kxlreadbitmapheader.html">     KXL_ReadBitmapHeader</a>
   <br> - <a href="./kxlcopyimagerect.html">        KXL_CopyImageRect</a>
   <br> - <a href="./kxlcopyimageimm.html">         KXL_CopyImageImm</a>
   <br> - <a href="./kxlcopyimage.html">            KXL_CopyImage</a> - For the compatibility of 1.1.4 or earlier

--- a/docs/kxlcopyimagerect.html
+++ b/docs/kxlcopyimagerect.html
@@ -8,7 +8,7 @@
 </head>
 <body text="#000000" bgcolor="#f0f0dc" link="#3366FF" vlink="#3366FF" alink="#FF0000">
 
-<a href="kxlloadbitmap.html">Prev</a>
+<a href="kxlreadbitmapheader.html">Prev</a>
 <a href="KXL.html">Top</a>
 <a href="kxlcopyimageimm.html">Next</a>
 <hr>

--- a/docs/kxlloadbitmap.html
+++ b/docs/kxlloadbitmap.html
@@ -10,7 +10,7 @@
 
 <a href="kxldrawpolygon.html">Prev</a>
 <a href="KXL.html">Top</a>
-<a href="kxlcopyimagerect.html">Next</a>
+<a href="kxlreadbitmapheader.html">Next</a>
 <hr>
 
 <b>Name</b><br><br>
@@ -33,7 +33,7 @@ The bitmap file must be saved in 4bpp(16 colors) or 8bpp(256 colors) color.
 <br><br>
 
 <b>Return Value</b><br><br>
-Pointer of KXL_Image structure.
+Pointer of KXL_Image structure, or NULL on failure.
 <br><br><br>
 
 <b>Exsample</b><br>

--- a/src/KXLimage.c
+++ b/src/KXLimage.c
@@ -105,16 +105,19 @@ void KXL_ReadBitmapHeader(const char *filename, KXL_BitmapHeader *hed)
   Uint16 i, j;
   Uint8  data;
 
+  hed->data = NULL;
+
   // ファイルを読み込み専用で開く
   if ((fp = fopen(filename,"rb")) == 0) {
     fprintf(stderr, "KXL error message\n'%s' is open error\n", filename);
-    exit(1);
+    return;
   }
   // ヘッダ読み込み
   fread(hed->magic, 1, 2, fp);
   if (hed->magic[0] != 'B' || hed->magic[1] != 'M') {
     fprintf(stderr, "KXL error message\n'%s' is not bitmap file\n", filename);
-    exit(1);
+    fclose(fp);
+    return;
   }
   hed->file_size  = KXL_ReadU32(fp);
   hed->reserved1  = KXL_ReadU16(fp);
@@ -129,7 +132,8 @@ void KXL_ReadBitmapHeader(const char *filename, KXL_BitmapHeader *hed)
   if (hed->depth < 4 || hed->depth > 8) {
     fprintf(stderr, "KXL error message\n'%s' %dbps not support\n", 
             filename, hed->depth);
-    exit(1);
+    fclose(fp);
+    return;
   }
   hed->lzd        = KXL_ReadU32(fp);
   hed->image_size = KXL_ReadU32(fp);
@@ -137,7 +141,8 @@ void KXL_ReadBitmapHeader(const char *filename, KXL_BitmapHeader *hed)
   if (hed->image_size == 0) {
     fprintf(stderr, "KXL error message\n'%s not found image size\n",
             filename);
-    exit(1);
+    fclose(fp);
+    return;
   }
   hed->x_pixels   = KXL_ReadU32(fp);
   hed->y_pixels   = KXL_ReadU32(fp);

--- a/src/KXLimage.c
+++ b/src/KXLimage.c
@@ -99,6 +99,7 @@ void KXL_CreateBitmap8to1(Uint8 *from, XImage *to, Uint8 blend)
 //  ビットマップヘッダ情報読み込み
 //  引き数：ファイル名
 //        ：ヘッダ情報のポインタ
+//  If the image data is NULL, that means the function has failed.
 //==============================================================
 void KXL_ReadBitmapHeader(const char *filename, KXL_BitmapHeader *hed)
 {

--- a/src/KXLimage.c
+++ b/src/KXLimage.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h> // for exit
+#include <sys/stat.h>
 #include "KXL.h"
 
 extern KXL_Window *KXL_Root;
@@ -106,12 +107,17 @@ void KXL_ReadBitmapHeader(const char *filename, KXL_BitmapHeader *hed)
   Uint8  data;
 
   hed->data = NULL;
+  struct stat st;
+  Bool stat_ok = 0;
 
   // ファイルを読み込み専用で開く
   if ((fp = fopen(filename,"rb")) == 0) {
     fprintf(stderr, "KXL error message\n'%s' is open error\n", filename);
     return;
   }
+  int fd = fileno(fp);
+  if (fd != -1)
+    stat_ok = !fstat(fd, &st);
   // ヘッダ読み込み
   fread(hed->magic, 1, 2, fp);
   if (hed->magic[0] != 'B' || hed->magic[1] != 'M') {
@@ -150,6 +156,20 @@ void KXL_ReadBitmapHeader(const char *filename, KXL_BitmapHeader *hed)
   hed->pals2      = KXL_ReadU32(fp);
   // 使用パレット数設定
   hed->pals = hed->pals ? hed->pals : (1 << hed->depth);
+  // Check if there is space for the palette.
+  if (stat_ok) {
+#if defined(_LP64) || defined(__LP64__)
+    off_t pos = ftello(fp);
+    if ((pos + 4 * (off_t)hed->pals) > st.st_size) {
+#else
+    long pos = ftell(fp);
+    if ((pos + 4 * (long)hed->pals) > st.st_size) {
+#endif
+      fprintf(stderr, "KXL error message\n'%s' not found palette or truncated", filename);
+      fclose(fp);
+      return;
+    }
+  }
   // カラーマップ取得
   hed->rgb = (KXL_RGBE *)KXL_Malloc(sizeof(KXL_RGBE) * hed->pals);
   for (i = 0; i < hed->pals; i ++) {
@@ -166,6 +186,21 @@ void KXL_ReadBitmapHeader(const char *filename, KXL_BitmapHeader *hed)
   }
   // 横幅を4の倍数で補正する
   hed->w = ((hed->width + 3) / 4) * 4;
+  // Check if there is space for the palette.
+  if (stat_ok) {
+#if defined(_LP64) || defined(__LP64__)
+    off_t pos = ftello(fp);
+    if ((pos + (off_t)hed->image_size) > st.st_size) {
+#else
+    long pos = ftell(fp);
+    if ((pos + (long)hed->image_size) > st.st_size) {
+#endif
+      fprintf(stderr, "KXL error message\n'%s' not found image data or truncated", filename);
+      free(hed->rgb);
+      fclose(fp);
+      return;
+    }
+  }
   // データ領域確保
   if (hed->depth == 8)
     hed->data = (Uint8 *)KXL_Malloc(hed->image_size);

--- a/src/KXLvisual.c
+++ b/src/KXLvisual.c
@@ -583,6 +583,8 @@ KXL_Image *KXL_LoadBitmap(const char *filename, Uint8 blend)
 
   // ビットマップヘッダ読込み
   KXL_ReadBitmapHeader(filename, &hed);
+  if (!hed.data)
+    return NULL;
   // イメージサイズ設定
   new = (KXL_Image *)KXL_Malloc(sizeof(KXL_Image));
   new->Width = hed.w;

--- a/src/KXLvisual.c
+++ b/src/KXLvisual.c
@@ -569,7 +569,7 @@ void KXL_DrawPolygon(KXL_Polygon *data, Uint16 max, Bool next, Bool flag)
 //==============================================================
 //  Load bitmap file of 8bits per pixel
 //  arguments    : File name
-//  Return value : Pointer of new image
+//  Return value : Pointer of new image, or NULL on failure
 //==============================================================
 KXL_Image *KXL_LoadBitmap(const char *filename, Uint8 blend)
 {


### PR DESCRIPTION
In *KXL_ReadBitmapHeader()*, there were a few places where execution would loop for a long time on a corrupt bitmap file, because `hed->pals` (the size of the `hed->rgb` color table) and `hed->image_size` were way too large, even larger than the remaining length of the file.

I've fixed the infinite loops by changing the function to bail out early if that happens. Also, I changed some **exit()** calls to instead simply clean up and return. Since `hed->data` is nulled near the beginning of ReadBitmapHeader, checking whether that's NULL is an easy way to tell if the function failed. Also, LoadBitmap can now return NULL.

TODO:
- [x] Document that if **ReadBitmapHeader()** fails, `hed->data` will be NULL.
- [x] Document that **LoadBitmap()** will now return NULL upon failure.