### PR TITLE
Deallocate PulseAudio handle in same process.

### DIFF
--- a/src/KXL.h
+++ b/src/KXL.h
@@ -176,7 +176,8 @@ typedef enum {
   KXL_SOUND_PLAY,        // Play sound
   KXL_SOUND_PLAY_LOOP,   // Loop play sound
   KXL_SOUND_STOP,        // Stop sound
-  KXL_SOUND_STOP_ALL     // Stop all sound
+  KXL_SOUND_STOP_ALL,    // Stop all sound
+  KXL_SOUND_QUIT         // Quit the sound server
 } KXL_Command;
 
 //================================================================

--- a/src/KXLsound.c
+++ b/src/KXLsound.c
@@ -282,9 +282,13 @@ void KXL_LoadSoundData(const char *path, char **fname)
 //==============================================================
 void KXL_InitSound(const char *path, char **fname)
 {
+  Uint16 i = 0;
   KXL_SoundOk = False;
 
   KXL_LoadSoundData(path, fname);
+  for (i = 0;i < KXL_SoundData.ListCnt;i++)
+    if (KXL_wavelist[i].Data == NULL)
+      return;
 #ifndef USE_PULSEAUDIO
   // device check
   if ((KXL_SoundData.Device = open("/dev/dsp", O_WRONLY)) == -1) {

--- a/src/KXLsound.c
+++ b/src/KXLsound.c
@@ -340,9 +340,6 @@ void KXL_InitSound(const char *path, char **fname)
 //==============================================================
 void KXL_EndSound(void)
 {
-  while (KXL_SoundData.ListCnt)
-    KXL_Free(KXL_wavelist[-- KXL_SoundData.ListCnt].Data);
-  KXL_Free(KXL_wavelist);
 #ifndef USE_PULSEAUDIO
   if (KXL_SoundData.Device != -1)
     close(KXL_SoundData.Device);
@@ -355,5 +352,8 @@ void KXL_EndSound(void)
       fprintf(stderr, "KXL error message\nsound server terminated abnormally");
     }
   }
+  while (KXL_SoundData.ListCnt)
+    KXL_Free(KXL_wavelist[-- KXL_SoundData.ListCnt].Data);
+  KXL_Free(KXL_wavelist);
 }
 

--- a/src/KXLsound.c
+++ b/src/KXLsound.c
@@ -348,9 +348,12 @@ void KXL_EndSound(void)
     KXL_PlaySound(0, KXL_SOUND_QUIT);
     int pid, status;
     pid = waitpid(KXL_SoundData.ID, &status, 0);
-    if (!WIFEXITED(status)) {
-      fprintf(stderr, "KXL error message\nsound server terminated abnormally");
+    if (WIFEXITED(status)) {
+      if (WEXITSTATUS(status))
+        fprintf(stderr, "KXL error message\nsound server exited with status %d", WEXITSTATUS(status));
     }
+    else
+      fprintf(stderr, "KXL error message\nsound server terminated abnormally");
   }
   while (KXL_SoundData.ListCnt)
     KXL_Free(KXL_wavelist[-- KXL_SoundData.ListCnt].Data);


### PR DESCRIPTION
The PulseAudio handle was being initialized in the child process (in _KXL_InitSound()_ at [**KXLsound.c**:302](https://github.com/Quipyowert2/libKXL/blob/a7aee1750877da078e08e75a35875edc4ed509c4/src/KXLsound.c#L302)), but freed in the parent process (_KXL_EndSound()_ at [**KXLsound.c**:335](https://github.com/Quipyowert2/libKXL/blob/a7aee1750877da078e08e75a35875edc4ed509c4/src/KXLsound.c#L335)). I don't know how that even worked before.

Also, I moved a _pa_simple_drain()_ call to the end of the sound server loop. This seems to make the sound less choppy.